### PR TITLE
Deterministic generation of IDs

### DIFF
--- a/.idea/puepy.iml
+++ b/.idea/puepy.iml
@@ -7,4 +7,11 @@
     <orderEntry type="jdk" jdkName="Poetry (puepy)" jdkType="Python SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
+  <component name="PackageRequirementsSettings">
+    <option name="requirementsPath" value="" />
+  </component>
+  <component name="PyDocumentationSettings">
+    <option name="format" value="GOOGLE" />
+    <option name="myDocStringFormat" value="Google" />
+  </component>
 </module>

--- a/puepy/core.py
+++ b/puepy/core.py
@@ -120,6 +120,13 @@ class Tag:
         else:
             raise Exception("No page passed")
 
+        if id in kwargs:
+            self._element_id = kwargs["id"]
+        elif self._page and self._page.application:
+            self._element_id = self._page.application.element_id_generator.get_id_for_element(self)
+        else:
+            self._element_id = f"ppauto-{id(self)}"
+
         if isinstance(parent, Tag):
             self.parent = parent
             parent.add(self)
@@ -238,7 +245,7 @@ class Tag:
 
     @property
     def element_id(self):
-        return self.attrs.get("id", f"e-{id(self)}")
+        return self._element_id
 
     @property
     def element(self):

--- a/tests/test_default_id_generator.py
+++ b/tests/test_default_id_generator.py
@@ -1,0 +1,25 @@
+import unittest
+import itertools
+from puepy.application import DefaultIdGenerator
+
+
+class TestDefaultIdGenerator(unittest.TestCase):
+    def setUp(self):
+        self.id_generator = DefaultIdGenerator("test")
+
+    def test_init(self):
+        self.assertEqual(self.id_generator.prefix, "test")
+        self.assertIsInstance(self.id_generator.counter, itertools.count)
+
+    def test_int_to_base36(self):
+        num = 10
+        self.assertEqual(DefaultIdGenerator._int_to_base36(num), "a")
+
+    def test_call(self):
+        ids = [self.id_generator.get_id_for_element(None) for _ in range(100)]
+        self.assertEqual(ids[0], "test0")
+        self.assertEqual(ids[99], "test2r")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Added a new class, DefaultIdGenerator, to generate serial IDs for elements using base36 encoding with an optional prefix. Modified the Application's constructor to accept an instance of an ID generator, defaulting to DefaultIdGenerator if none is provided.

This makes both testing and, possibly, sever-side rendering more feasible, since ids are entirely predictable now, with the option to override how they're generated.