### PR TITLE
Always retain changed element values

### DIFF
--- a/puepy/core.py
+++ b/puepy/core.py
@@ -477,15 +477,11 @@ class Tag:
 
     def _retain_implicit_attrs(self):
         """
-        Some web components add attributes after their elements are rendered. Eg, <sl-button> becomes <sl-button variant="default">
-
-        If we patch the DOM and remove those attributes, we lose them. This method is called recursively on redraw
-        to retain any attributes that were added by the web component.
+        Retain attributes set elsewhere
         """
-        if getattr(self.element, "shadowRoot"):
-            for attr in self.element.attributes:
-                if attr.name not in self.attrs and attr.name != "id":
-                    self._retained_attrs[attr.name] = attr.value
+        for attr in self.element.attributes:
+            if attr.name not in self.attrs and attr.name != "id":
+                self._retained_attrs[attr.name] = attr.value
 
     def on_redraw(self):
         pass


### PR DESCRIPTION
In past versions of PuePy, we checked for a shadow DOM and retained changes to elements if such a shadow DOM was present. The idea was, Web Components sometimes changed their attributes and we wanted to retain that.

That check was unnecessary. Not all web components (custom elements) create shadow DOMs, and even if the changes came from elsewhere, there's little reason to discard them.