### PR TITLE
Stop using kwargs to generate refs

### DIFF
--- a/puepy/core.py
+++ b/puepy/core.py
@@ -895,10 +895,7 @@ class Builder:
             raise Exception("t.generate_tag called without a context")
 
         # Determine ref value
-        ref_part = "__" + (
-            f"{parent.ref}.{tag_name}{len(parent.children) + 1}_"
-            + (binascii.hexlify(hashlib.sha256(str(kwargs).encode()).digest()))[:8].decode("utf8")
-        ).lstrip("_")
+        ref_part = "__" + (f"{parent.ref}.{tag_name}_{len(parent.children) + 1}").lstrip("_")
 
         ref = kwargs.pop("ref", ref_part)
 

--- a/puepy/core.py
+++ b/puepy/core.py
@@ -1,6 +1,3 @@
-import binascii
-import hashlib
-
 from .exceptions import ElementNotInDom, PropsError, PageError
 from .reactivity import ReactiveDict, Stateful
 from .runtime import (


### PR DESCRIPTION
Previously, to decide whether to re-use or create new components/tags, PuePy would include a "ref hash" that included kwargs (props) passed to the component.

That was foolish. Props change, but the component should still be the same.